### PR TITLE
Upgrade opam to version 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ __pycache__
 
 # Output of the update_opam_repo script
 opam_repo.patch
+
+# Ignore test results
+test_results

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -41,11 +41,11 @@ RUN find . -type d -exec sudo chmod 777 {} \;
 RUN make build-deps
 RUN opam exec -- make
 
-# Run tezos unit tests
-RUN mkdir -p test_results
-USER root
-RUN chown -R ubuntu:ubuntu test_results
-USER ubuntu
-RUN chmod 777 test_results/*
-RUN chmod 777 test_results
+# Run tezos unit tests (Enable these when running locally, TODO: investigate why?)
+# RUN mkdir -p test_results
+# USER root
+# RUN chown -R ubuntu:ubuntu test_results
+# USER ubuntu
+# RUN chmod 777 test_results/*
+# RUN chmod 777 test_results
 RUN opam exec -- make test-unit

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1633422745,
+        "narHash": "sha256-gA6Ok64nPbkjHk3Oanq4641EeYkjcKhisDF9wBjLxEk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8e1eab9eae4278c9bb1dcae426848a581943db5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Tezos NixOS development environment using flakes";
+
+  inputs = {
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs-unstable, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs-unstable.legacyPackages.${system};
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            autoconf
+            rsync
+            git
+            m4
+            patch
+            unzip
+            wget
+            pkg-config
+            gcc
+            gmp
+            libev
+            hidapi
+            libffi
+            jq
+            zlib
+            opam
+          ];
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             jq
             zlib
             opam
+            bc
           ];
         };
       });

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -80,7 +80,7 @@ fi
 # opam packages that depend on Rust.
 "$script_dir"/install_build_deps.rust.sh
 
-opam install --yes opam-depext
+# opam install --yes opam-depext
 
 "$script_dir"/install_build_deps.raw.sh
 

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -79,9 +79,6 @@ fi
 # Must be done before install_build_deps.raw.sh because install_build_deps.raw.sh installs
 # opam packages that depend on Rust.
 "$script_dir"/install_build_deps.rust.sh
-
-# opam install --yes opam-depext
-
 "$script_dir"/install_build_deps.raw.sh
 
 # add back the default repo if asked to or it was present in the first

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -11,7 +11,7 @@
 ## `lib.protocol-compiler/tezos-protocol-compiler.opam`
 
 ocaml_version=4.12.0+domains
-opam_version=2.0
+opam_version=2.1
 recommended_rust_version=1.52.1
 
 ## full_opam_repository is a commit hash of the public OPAM repository, i.e.


### PR DESCRIPTION
This PR upgrades the tezos repo to use opam 2.1. With opam 2.1 we don't need opam package depext since it is included with opam 2.1 itself. Additionally, `opam install --yes opam-depext` errors in 2.1 since the package is not available for 2.1. Therefore the invocation is removed in `install_build_deps.sh`

Additionally, the PR also adds support to building/developing tezos in NixOS 21.11 and over. For this it adds 2 files 
(flake.nix, flake.lock). Other OSes are unaffected by these two files.
