### PR TITLE
fix make error on fmt

### DIFF
--- a/src/lib_stdlib_unix/dune
+++ b/src/lib_stdlib_unix/dune
@@ -12,6 +12,7 @@
   lwt.unix
   ipaddr.unix
   re
+  fmt
   ptime
   ptime.clock.os
   mtime


### PR DESCRIPTION
This PR fixes the build error below.

File "src/lib_stdlib_unix/file_descriptor_sink.ml", line 111, characters 24-36:
111 |                         Fmt.failwith "Wrong level name: %S in argument %S" two s
                              ^^^^^^^^^^^^
Error: Unbound module Fmt
